### PR TITLE
Fixes cyclic import problems.

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -121,7 +121,7 @@ function compilationErrors(filePath, documentText): Diagnostic[] {
             },
             settings: {
                 outputSelection: ['metadata'],
-                remappings: compilerRemappings.map(mapping => `${mapping.prefix}=${mapping.target}`),
+                remappings: compilerRemappings.map(mapping => `${mapping.prefix}=${path.resolve(mapping.target).replace(/\\/g, '\/')}`),
             },
             sources: contracts.getContractsForCompilation(),
         };


### PR DESCRIPTION
solc uses the resolved file path as a lookup key to determine when it needs to load a file vs when it should use a previously loaded file.  This means that if the user provides a relative path for the remapping, the key won't match the already loaded file and so it will load the file anew and run into a conflict.

solc also doesn't normalize path separators before using the path as a key, which means that the paths have to be strongly normalized before hand across everything.  Since Windows works with both forward and backward slashes, its easiest to just use forward slash in this case (everything else appears to fall out naturally).

Strongly recommend testing on OSX/Linux before releasing if possible, as I have only tested this locally.